### PR TITLE
feat(worker-rpc): improve types

### DIFF
--- a/.changeset/busy-moons-change.md
+++ b/.changeset/busy-moons-change.md
@@ -1,0 +1,5 @@
+---
+"@deox/worker-rpc": patch
+---
+
+Improve TypeScript type inference and export additional internal types to help bundlers and tooling generate more accurate type annotations.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Internal Packages for personal projects (Plus UI, Web Apps, etc)",
   "author": "Deo Kumar",
   "homepage": "https://github.com/kumardeo/deox",
-  "packageManager": "pnpm@11.1.2",
+  "packageManager": "pnpm@11.1.3",
   "scripts": {
     "format": "biome format --max-diagnostics=100 --log-kind=compact",
     "format:all": "pnpm run format .",

--- a/packages/gumroad/package.json
+++ b/packages/gumroad/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "catalog:",
-    "hono": "^4.12.18",
+    "hono": "^4.12.19",
     "tsdown": "catalog:",
     "wrangler": "catalog:"
   }

--- a/packages/worker-rpc/dev/index.ts
+++ b/packages/worker-rpc/dev/index.ts
@@ -63,6 +63,8 @@ worker.addEventListener('message', (event) => {
   console.log('(thread:main)', await worker.call('transferToMain'));
 
   console.log('(thread:main)', await worker.call('getByteLength'));
+
+  worker.call({ signal: AbortSignal.timeout(5000) }, 'wait', 10000);
 })().catch(console.error);
 
 // Expose to window for external uses

--- a/packages/worker-rpc/dev/worker.ts
+++ b/packages/worker-rpc/dev/worker.ts
@@ -5,7 +5,7 @@ declare let self: DedicatedWorkerGlobalScope;
 const registered = register((ctx: { info: string }) => {
   const bytes = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
 
-  return {
+  const methods = {
     thisError: new Error('Custom error!'),
     hello: () => 'Hello from worker',
     sum: (...numbers: number[]) => numbers.reduce((p, c) => p + c),
@@ -23,7 +23,12 @@ const registered = register((ctx: { info: string }) => {
     getByteLength() {
       return bytes.byteLength;
     },
+    async wait(seconds: number) {
+      await new Promise((res) => setTimeout(res, seconds * 1000));
+    },
   };
+
+  return methods;
 });
 
 // This should not log any event

--- a/packages/worker-rpc/src/constants.ts
+++ b/packages/worker-rpc/src/constants.ts
@@ -1,1 +1,1 @@
-export const WORKER_NAMESPACE = '____{{DEOX_WORKER_RPC}}____';
+export const WORKER_NAMESPACE: string = '____{{DEOX_WORKER_RPC}}____';

--- a/packages/worker-rpc/src/index.ts
+++ b/packages/worker-rpc/src/index.ts
@@ -1,16 +1,16 @@
 import { generateId } from '@deox/utils/generate-id';
 import { WORKER_NAMESPACE } from './constants';
 import type {
-  Await,
   InferContext,
-  InferMethodsMap,
+  InferMethods,
   InferProxyType,
   InferWorkerOptions,
-  MayBePromise,
   MessageMain,
   MessageWorker,
   MessageWorkerInput,
+  MethodsMap,
   RegisterOutput,
+  RequestOptions,
 } from './types';
 import { eventIsResponse, getBlobContent } from './utils';
 
@@ -91,22 +91,25 @@ const ExtendWorker = (MayBeWorker as (typeof globalThis)['Worker']) ?? DummyWork
  * the methods called using Worker instance will always return a Promise which resolves or rejects based on method logic.
  */
 export class Worker<
-  R extends RegisterOutput<(ctx: any) => MayBePromise<NonNullable<object>>> = RegisterOutput<(ctx: undefined) => never>,
+  R extends RegisterOutput<NonNullable<object>, any> = RegisterOutput<Record<string | number, (...args: unknown[]) => unknown>, unknown>,
 > extends ExtendWorker {
+  /** The context provided through options (to be sent to worker) */
+  private _context: InferContext<R>;
+
   /** A promise which resolves when context is sent to worker */
   private _setup: Promise<void>;
 
   /** A map of pending requests containing functions to resolve or reject */
-  private _queue: Map<string, [(value: any) => void, (error: any) => void]>;
+  private _queue: Map<string, { resolve: (value: any) => void; reject: (error: any) => void }>;
 
   /** A proxy which can to used as an alternative for `call` method */
   private _proxy: InferProxyType<R> | undefined;
 
+  /** Indicates whether worker has been terminated */
+  private _terminated: boolean;
+
   /** A function which generates unique request id */
   private _generate: (message: MessageWorkerInput) => string;
-
-  /** The context provided through options (to be sent to worker) */
-  private _context: InferContext<R>;
 
   /**
    * A method to request to worker
@@ -115,17 +118,33 @@ export class Worker<
    *
    * @returns The response message object
    */
-  private _request(message: MessageWorkerInput, options?: StructuredSerializeOptions | Transferable[]): Promise<MessageMain> {
-    const requestId = this._generate(message);
-    const messageData: MessageWorker = {
-      ...message,
-      id: requestId,
-    };
-    Object.assign(messageData, { [WORKER_NAMESPACE]: true });
+  private _request(message: MessageWorkerInput, options: RequestOptions = {}): Promise<MessageMain> {
     return new Promise<MessageMain>((resolve, reject) => {
-      this._queue.set(requestId, [resolve, reject]);
-      if (options) {
-        this.postMessage(messageData, Array.isArray(options) ? { transfer: options } : options);
+      const { transfer, signal } = Array.isArray(options) ? { transfer: options } : options;
+
+      if (signal?.aborted) {
+        return reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
+      }
+
+      signal?.addEventListener(
+        'abort',
+        () => {
+          this._queue.delete(requestId);
+          reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
+        },
+        { once: true },
+      );
+
+      const requestId = this._generate(message);
+      const messageData: MessageWorker = {
+        ...message,
+        id: requestId,
+      };
+      Object.assign(messageData, { [WORKER_NAMESPACE]: true });
+
+      this._queue.set(requestId, { resolve, reject });
+      if (transfer) {
+        this.postMessage(messageData, { transfer });
       } else {
         this.postMessage(messageData);
       }
@@ -140,53 +159,54 @@ export class Worker<
    */
   constructor(scriptURL: string | URL, options: InferWorkerOptions<R>) {
     const workerUrl = scriptURL instanceof URL ? scriptURL : new URL(scriptURL, window.location.href);
-    const workerOptions = options || {};
 
     // construct normally if script url is same-origin otherwise use blob url
     if (workerUrl.origin === window.location.origin) {
-      super(scriptURL, workerOptions);
+      super(scriptURL, options);
     } else {
       const blob = new Blob([getBlobContent(workerUrl.href, options?.type)], {
         type: 'text/javascript',
       });
-      super(URL.createObjectURL(blob), workerOptions);
+      super(URL.createObjectURL(blob), options);
     }
 
     this._queue = new Map();
+    this._context = options?.context as InferContext<R>;
+    this._terminated = false;
 
     this._generate = (message) => {
       let id: string;
       do {
-        id = typeof workerOptions.generate === 'function' ? workerOptions.generate(message) : `worker_${message.type}_${generateId()}`;
+        id = typeof options?.generate === 'function' ? options.generate(message) : `worker_${message.type}_${generateId()}`;
       } while (this._queue.has(id));
       return id;
     };
 
     // add message event listener to handle responses
     this.addEventListener('message', (event: MessageEvent<MessageMain>) => {
-      // check if message was sent through register function of worker thread
-      if (eventIsResponse(event)) {
-        // stop propagation to make sure next listeners do not get invoked since message was not sent by user
-        event.stopImmediatePropagation();
+      // ensure message is received through register function of worker thread
+      if (!eventIsResponse(event)) {
+        return;
+      }
 
-        const response = event.data;
+      // stop propagation to make sure next listeners do not get invoked since message was not sent by user
+      event.stopImmediatePropagation();
 
-        const { type: responseType, id: responseId } = response;
+      const response = event.data;
 
-        // pending request corresponding with the response id
-        const pendingData = this._queue.get(responseId);
+      const { type: responseType, id: responseId } = response;
 
-        if (['response', 'context'].includes(responseType) && typeof pendingData !== 'undefined') {
-          // resolve the request with response data from worker
-          pendingData[0](response);
+      // pending request corresponding with the response id
+      const pendingRequest = this._queue.get(responseId);
 
-          // remove the pending request form queue
-          this._queue.delete(responseId);
-        }
+      if (['response', 'context'].includes(responseType) && typeof pendingRequest !== 'undefined') {
+        // remove the pending request form queue
+        this._queue.delete(responseId);
+
+        // resolve the request with response data from worker
+        pendingRequest.resolve(response);
       }
     });
-
-    this._context = workerOptions.context;
 
     this._setup = this._request({
       type: 'context',
@@ -210,7 +230,10 @@ export class Worker<
    *
    * @returns A Promise which resolves with the return value of the handler
    */
-  async call<N extends keyof InferMethodsMap<R>>(name: N, ...args: InferMethodsMap<R>[N][0]): Promise<Await<InferMethodsMap<R>[N][1]>>;
+  async call<N extends keyof MethodsMap<InferMethods<R>>>(
+    name: N,
+    ...args: Parameters<MethodsMap<InferMethods<R>>[N]>
+  ): Promise<Awaited<ReturnType<MethodsMap<InferMethods<R>>[N]>>>;
   /**
    * Call registered method from worker thread and also transfer `Transferable`
    *
@@ -220,27 +243,31 @@ export class Worker<
    *
    * @returns A Promise which resolves with the return value of the handler
    */
-  async call<N extends keyof InferMethodsMap<R>, O extends StructuredSerializeOptions | Transferable[]>(
-    options: O,
+  async call<N extends keyof MethodsMap<InferMethods<R>>>(
+    options: RequestOptions,
     name: N,
-    ...args: InferMethodsMap<R>[N][0]
-  ): Promise<Await<InferMethodsMap<R>[N][1]>>;
+    ...args: Parameters<MethodsMap<InferMethods<R>>[N]>
+  ): Promise<Awaited<ReturnType<MethodsMap<InferMethods<R>>[N]>>>;
 
-  async call<N extends keyof InferMethodsMap<R>>(
-    ...rest: [N, ...InferMethodsMap<R>[N][0]] | [StructuredSerializeOptions | Transferable[], N, ...InferMethodsMap<R>[N][0]]
-  ): Promise<Await<InferMethodsMap<R>[N][1]>> {
+  async call<N extends keyof MethodsMap<InferMethods<R>>>(
+    ...rest: [N, ...Parameters<MethodsMap<InferMethods<R>>[N]>] | [RequestOptions, N, ...Parameters<MethodsMap<InferMethods<R>>[N]>]
+  ): Promise<Awaited<ReturnType<MethodsMap<InferMethods<R>>[N]>>> {
+    if (this._terminated) {
+      throw new Error('Worker is terminated');
+    }
+
     if (!['string', 'number', 'object'].includes(typeof rest[0]) || rest[0] === null) {
       throw new TypeError('Argument 1 must be of type string, number, object or array');
     }
 
     let name: N;
-    let args: InferMethodsMap<R>[N][0];
-    let options: StructuredSerializeOptions | Transferable[] | undefined;
+    let args: Parameters<MethodsMap<InferMethods<R>>[N]>;
+    let options: RequestOptions | undefined;
     const hasOptions = typeof rest[0] === 'object';
     if (hasOptions) {
-      [options, name, ...args] = rest as [StructuredSerializeOptions | Transferable[], N, ...InferMethodsMap<R>[N][0]];
+      [options, name, ...args] = rest as [RequestOptions, N, ...Parameters<MethodsMap<InferMethods<R>>[N]>];
     } else {
-      [name, ...args] = rest as [N, ...InferMethodsMap<R>[N][0]];
+      [name, ...args] = rest as [N, ...Parameters<MethodsMap<InferMethods<R>>[N]>];
     }
 
     // throw an error if name is neither string nor number
@@ -266,7 +293,7 @@ export class Worker<
 
     switch (response.status) {
       case 'success':
-        return response.body as Await<InferMethodsMap<R>[N][1]>;
+        return response.body as Awaited<ReturnType<MethodsMap<InferMethods<R>>[N]>>;
       case 'error':
         throw response.error;
       case 'not-found':
@@ -285,14 +312,37 @@ export class Worker<
       __proto__: new Proxy(
         {},
         {
-          get:
-            <P extends keyof InferMethodsMap<R>>(_: unknown, prop: P) =>
-            (...args: InferMethodsMap<R>[P][0]) =>
-              this.call(prop, ...args),
+          get: (_: unknown, prop) => {
+            return <P extends keyof MethodsMap<InferMethods<R>>>(...args: Parameters<MethodsMap<InferMethods<R>>[P]>) => {
+              return this.call(prop as P, ...args);
+            };
+          },
         },
       ),
     } as InferProxyType<R>;
 
     return this._proxy;
   }
+
+  override terminate(): void {
+    super.terminate();
+    this._terminated = true;
+    const error = new Error('Worker terminated');
+    for (const { reject } of this._queue.values()) {
+      reject(error);
+    }
+    this._queue.clear();
+  }
 }
+
+export type {
+  CallerType,
+  InferContext,
+  InferMethods,
+  InferWorkerOptions,
+  IWorkerOptions as WorkerOptions,
+  MessageMain,
+  MessageWorker,
+  RegisterInput,
+  RegisterOutput,
+} from './types';

--- a/packages/worker-rpc/src/register/index.ts
+++ b/packages/worker-rpc/src/register/index.ts
@@ -1,6 +1,6 @@
 import { DeferredPromise } from '@deox/utils/deferred-promise';
-import type { MayBePromise, MessageWorker, Params, RegisterOutput } from '../types';
-import { type HandlerType, handle, isRequestEvent, MessageEventHandler, respond, WithOptions } from './utils';
+import type { MessageWorker, RegisterInput, RegisterOutput } from '../types';
+import { createMethodsResolver, InternalWithOptions, isRequestEvent, MessageEventHandler, type MethodsResolver, respond } from './utils';
 
 const eventHandler = new MessageEventHandler<MessageWorker>();
 
@@ -11,86 +11,86 @@ const eventHandler = new MessageEventHandler<MessageWorker>();
  *
  * @returns An object which has a `call` method
  */
-export function register<F extends (ctx?: any) => MayBePromise<NonNullable<object>>>(input: F): RegisterOutput<F> {
+export function register<M extends NonNullable<object>, C>(input: RegisterInput<M, C>): RegisterOutput<M, C> {
   // throw an error if input argument is not a function
   if (typeof input !== 'function') {
     throw new TypeError('Argument 1 must be of type function.');
   }
 
-  const contextPromise = new DeferredPromise<HandlerType<F>>();
+  const contextPromise = new DeferredPromise<MethodsResolver<M>>();
 
-  eventHandler.set((event) => {
-    // Check if valid request
-    if (isRequestEvent(event)) {
-      // Stop propagation
-      event.stopImmediatePropagation();
+  eventHandler.attach((event) => {
+    // Ensure valid request
+    if (!isRequestEvent(event)) {
+      return;
+    }
 
-      const request = event.data;
+    // Stop propagation
+    event.stopImmediatePropagation();
 
-      if (request.type === 'context') {
-        try {
-          const result = handle(input, request.context);
-          contextPromise.resolve(result);
-        } catch (error) {
-          contextPromise.reject(error);
-        }
+    const request = event.data;
 
-        contextPromise
-          .then(() => {
-            respond.contextSuccess(request.id);
-          })
-          .catch((error) => {
-            respond.contextError(request.id, error);
-          });
-      } else if (request.type === 'request') {
-        if (['string', 'number'].includes(typeof request.handler)) {
-          const handleData = (data: unknown) => {
-            if (data instanceof WithOptions) {
-              respond.handlerSuccess(request.id, request.handler, data.result, data.options);
-            } else {
-              respond.handlerSuccess(request.id, request.handler, data);
-            }
-          };
+    if (request.type === 'context') {
+      const resolver = createMethodsResolver(input, request.context as C);
+      contextPromise.resolve(resolver);
 
-          const handleError = (error: unknown) => {
-            respond.handlerError(request.id, request.handler, error);
-          };
+      contextPromise
+        .then(() => {
+          respond.contextSuccess(request.id);
+        })
+        .catch((error) => {
+          respond.contextError(request.id, error);
+        });
 
-          contextPromise
-            .then(async (result) => {
-              const object = await result.getObject();
-              if (request.handler in object) {
-                try {
-                  result
-                    // @ts-expect-error it will throw error if handler is not there
-                    .call(request.handler, ...request.arguments)
-                    .then(handleData)
-                    .catch(handleError);
-                } catch (error) {
-                  handleError(error);
-                }
-              } else {
-                respond.handlerNotFound(request.id, request.handler);
-              }
-            })
-            .catch(handleError);
-        }
+      return;
+    }
+
+    if (request.type === 'request') {
+      if (!['string', 'number'].includes(typeof request.handler)) {
+        return;
       }
+
+      const handleData = (data: unknown) => {
+        if (data instanceof InternalWithOptions) {
+          respond.handlerSuccess(request.id, request.handler, data.result, data.options);
+        } else {
+          respond.handlerSuccess(request.id, request.handler, data);
+        }
+      };
+
+      const handleError = (error: unknown) => {
+        respond.handlerError(request.id, request.handler, error);
+      };
+
+      contextPromise
+        .then(async (resolver) => {
+          const methods = await resolver.get();
+          if (request.handler in methods) {
+            resolver
+              // @ts-expect-error it will throw error if handler is not there
+              .call(request.handler, ...request.arguments)
+              .then(handleData)
+              .catch(handleError);
+          } else {
+            respond.handlerNotFound(request.id, request.handler);
+          }
+        })
+        .catch(handleError);
+
+      return;
     }
   });
 
-  const result: RegisterOutput<F> = (context: Params<F>[0]) => {
-    const handler = handle(input, context);
+  return (ctx) => {
+    const resolver = createMethodsResolver(input, ctx);
 
     return {
       call(name, ...args) {
-        return handler.call(name, ...args);
+        return resolver.call(name, ...args);
       },
     };
   };
-
-  return result;
 }
 
-export type { MessageMain, MessageWorker } from '../types';
+export type { CallerType, MessageMain, MessageWorker, RegisterInput, RegisterOutput, WithOptions } from '../types';
 export { withOptions } from './utils';

--- a/packages/worker-rpc/src/register/utils.ts
+++ b/packages/worker-rpc/src/register/utils.ts
@@ -1,13 +1,13 @@
 /// <reference lib="WebWorker" />
 
 import { WORKER_NAMESPACE } from '../constants';
-import type { Await, AwaitReturn, MayBePromise, MessageMain, MessageMainInput, MethodsMap, WithOptionsInstance } from '../types';
+import type { CallerType, MessageMain, MessageMainInput, WithOptions } from '../types';
 
 declare let self: DedicatedWorkerGlobalScope;
 
-export class WithOptions<T> implements WithOptionsInstance<T> {
-  result: T;
-  options: StructuredSerializeOptions | Transferable[];
+export class InternalWithOptions<T> implements WithOptions<T> {
+  readonly result: T;
+  readonly options: StructuredSerializeOptions | Transferable[];
 
   constructor(result: T, options: StructuredSerializeOptions | Transferable[]) {
     this.result = result;
@@ -16,7 +16,7 @@ export class WithOptions<T> implements WithOptionsInstance<T> {
 }
 
 export function withOptions<T>(result: T, options: StructuredSerializeOptions | Transferable[]): WithOptions<T> {
-  return new WithOptions(result, options);
+  return new InternalWithOptions(result, options);
 }
 
 /**
@@ -138,14 +138,6 @@ export const respond = {
   },
 };
 
-/** utility to convert data to promise */
-export function toPromise<T = any>(data: T): Promise<Await<T>> {
-  if (data instanceof Promise) {
-    return data as Promise<Await<T>>;
-  }
-  return Promise.resolve(data);
-}
-
 /** checks if message event is request */
 export function isRequestEvent(event: MessageEvent<unknown>): boolean {
   const request = event.data;
@@ -153,46 +145,39 @@ export function isRequestEvent(event: MessageEvent<unknown>): boolean {
   return !!request && typeof request === 'object' && Object.hasOwn(request, WORKER_NAMESPACE);
 }
 
-export type HandlerType<F extends (ctx?: any) => MayBePromise<NonNullable<object>>> = {
-  __resolved: AwaitReturn<F> | undefined;
-  getObject: () => Promise<AwaitReturn<F>>;
-  call: <N extends keyof MethodsMap<AwaitReturn<F>>>(
-    name: N,
-    ...args: MethodsMap<AwaitReturn<F>>[N][0]
-  ) => Promise<Await<MethodsMap<AwaitReturn<F>>[N][1]>>;
-};
+export interface MethodsResolver<M> {
+  readonly get: () => Promise<M>;
+  readonly call: CallerType<M>;
+}
 
-export function handle<F extends (ctx?: any) => MayBePromise<NonNullable<object>>>(input: F, context: Parameters<F>[0]): HandlerType<F> {
-  const result: HandlerType<F> = {
-    __resolved: undefined,
-    async getObject(): Promise<AwaitReturn<F>> {
-      if (!this.__resolved) {
-        this.__resolved = (await toPromise(input(context))) as AwaitReturn<F>;
-      }
-      return this.__resolved;
-    },
-    async call(name, ...args) {
-      // throw an error if name is neither string nor number
-      if (!['string', 'number'].includes(typeof name)) {
-        throw new TypeError('Argument 1 must be of type string or number');
-      }
+export function createMethodsResolver<M extends NonNullable<object>, C>(input: (ctx: C) => M | Promise<M>, ctx: C): MethodsResolver<M> {
+  let resolved: M | undefined;
 
-      const methods = await this.getObject();
-
-      if (!Object.hasOwn(methods, name)) {
-        throw new Error(`Method '${String(name)}' does not exists.`);
-      }
-
-      if (typeof methods[name] !== 'function') {
-        throw new Error(`Property '${String(name)}' is not a function.`);
-      }
-
-      // @ts-expect-error: we did type checks, safe to call the method
-      return methods[name](...args);
-    },
+  const get = async (): Promise<M> => {
+    resolved ??= await input(ctx);
+    return resolved;
   };
 
-  return result;
+  const call = (async (name, ...args) => {
+    // throw an error if name is neither string nor number
+    if (!['string', 'number'].includes(typeof name)) {
+      throw new TypeError('Argument 1 must be of type string or number');
+    }
+
+    const methods = await get();
+
+    if (!Object.hasOwn(methods, name)) {
+      throw new Error(`Method '${String(name)}' does not exists.`);
+    }
+
+    if (typeof methods[name] !== 'function') {
+      throw new Error(`Property '${String(name)}' is not a function.`);
+    }
+
+    return methods[name](...args);
+  }) as CallerType<M>;
+
+  return { get, call };
 }
 
 export type MessageHandler<T = any> = (event: MessageEvent<T>) => void;
@@ -212,7 +197,7 @@ export class MessageEventHandler<T = any> {
     this.current = undefined;
   }
 
-  set(handler: MessageHandler<T>): void {
+  attach(handler: MessageHandler<T>): void {
     this.remove();
     this.current = handler;
     self.addEventListener('message', this.current);

--- a/packages/worker-rpc/src/types.ts
+++ b/packages/worker-rpc/src/types.ts
@@ -1,80 +1,42 @@
-/* utils types */
-export type Return<T extends (...args: any) => any> = ReturnType<T>;
-
-export type Params<T extends (...args: any) => any> = Parameters<T>;
-
-export type Await<T> = Awaited<T>;
-
-export type Async<T> = Promise<Await<T>>;
-
-export type AwaitReturn<T extends (...args: any[]) => any> = Await<Return<T>>;
-
-export type MayBePromise<T> = T extends Promise<infer C> ? C | Promise<C> : T | Promise<T>;
-
-export type Inc<T, U> = T extends U ? T : never;
-
-export type Exc<T, U> = T extends U ? never : T;
-
-export type PickProps<T, K> = { [P in Inc<keyof T, K>]: T[P] };
-
-export type OmitProps<T, K> = { [P in Exc<keyof T, K>]: T[P] };
-
-/* worker types */
-export interface WithOptionsInstance<T> {
-  result: T;
-  options: StructuredSerializeOptions | Transferable[];
+export interface WithOptions<T> {
+  readonly result: T;
+  readonly options: StructuredSerializeOptions | Transferable[];
 }
 
-export type MethodsMap<T, I extends string | number | symbol = string | number, E extends string | number | symbol = never> = OmitProps<
-  PickProps<
-    {
-      [K in keyof T as T[K] extends (...args: any[]) => any ? K : never]: T[K] extends (...args: any[]) => any
-        ? [
-            Params<T[K]>,
-            Return<T[K]> extends Promise<WithOptionsInstance<infer R>>
-              ? Promise<R>
-              : Return<T[K]> extends WithOptionsInstance<infer R>
-                ? R
-                : Return<T[K]>,
-          ]
-        : never;
-    },
-    I
-  >,
-  E
->;
-
-export type RegisterInput = (ctx?: any) => MayBePromise<NonNullable<object>>;
-
-export type RegisterOutput<F extends RegisterInput> = (context: Params<F>[0]) => {
-  call<N extends keyof MethodsMap<AwaitReturn<F>>>(
-    name: N,
-    ...args: MethodsMap<AwaitReturn<F>>[N][0]
-  ): Promise<Await<MethodsMap<AwaitReturn<F>>[N][1]>>;
+export type MethodsMap<T> = {
+  [K in Extract<keyof T, string | number> as T[K] extends (...args: any[]) => any ? K : never]: T[K] extends (...args: any[]) => any
+    ? (...args: Parameters<T[K]>) => Promise<Awaited<Awaited<ReturnType<T[K]>> extends WithOptions<infer R> ? R : ReturnType<T[K]>>>
+    : never;
 };
 
-export type InferFunction<R extends RegisterInput> = R extends RegisterOutput<infer F> ? F : never;
+export type CallerType<M> = <N extends keyof MethodsMap<M>>(name: N, ...args: Parameters<MethodsMap<M>[N]>) => ReturnType<MethodsMap<M>[N]>;
 
-export type InferContext<R extends RegisterInput> = Params<InferFunction<R>>[0];
+export type RegisterInput<M extends NonNullable<object>, C> = (ctx: C) => M | Promise<M>;
 
-export type InferMethodsMap<R extends RegisterInput> = Omit<MethodsMap<AwaitReturn<InferFunction<R>>>, symbol>;
-
-export type InferProxyType<R extends RegisterInput> = {
-  readonly [K in keyof InferMethodsMap<R>]: (...args: InferMethodsMap<R>[K][0]) => Promise<Await<InferMethodsMap<R>[K][1]>>;
+export type RegisterOutput<M extends NonNullable<object>, C> = (ctx: C) => {
+  call: CallerType<M>;
 };
 
-export type InferWorkerOptions<R extends RegisterOutput<RegisterInput>> =
-  InferContext<R> extends undefined | undefined
-    ?
-        | (WorkerOptions & {
-            context?: InferContext<R>;
-            generate?: (message: MessageWorkerInput) => string;
-          })
-        | undefined
-    : WorkerOptions & {
-        context: InferContext<R>;
-        generate?: (message: MessageWorkerInput) => string;
-      };
+export type IsOptionalContext<C> = [C] extends [undefined] ? true : [C] extends [never] ? false : [unknown] extends [C] ? true : false;
+
+export type IWorkerOptions<C> = (WorkerOptions & {
+  generate?: (message: MessageWorkerInput) => string;
+}) &
+  (IsOptionalContext<C> extends true ? { context?: C } : { context: C });
+
+export type RequestOptions =
+  | (StructuredSerializeOptions & {
+      signal?: AbortSignal;
+    })
+  | Transferable[];
+
+export type InferMethods<R extends RegisterOutput<any, any>> = R extends RegisterOutput<infer M, any> ? M : never;
+
+export type InferContext<R extends RegisterOutput<any, any>> = R extends RegisterOutput<any, infer C> ? C : never;
+
+export type InferProxyType<R extends RegisterOutput<any, any>> = Readonly<MethodsMap<InferMethods<R>>>;
+
+export type InferWorkerOptions<R extends RegisterOutput<any, any>> = IWorkerOptions<InferContext<R>>;
 
 /* message types */
 export type MessageWorkerInput =
@@ -110,7 +72,7 @@ export type MessageMainInput =
     } & (
       | {
           status: 'success';
-          body: any;
+          body: unknown;
         }
       | {
           status: 'error';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   default:
     '@cloudflare/workers-types':
-      specifier: ^4.20260515.1
-      version: 4.20260515.1
+      specifier: ^4.20260519.1
+      version: 4.20260519.1
     '@types/node':
-      specifier: ^25.8.0
-      version: 25.8.0
+      specifier: ^25.9.0
+      version: 25.9.0
     '@types/react':
       specifier: ^19.2.14
       version: 19.2.14
@@ -25,8 +25,8 @@ catalogs:
       specifier: ^8.0.13
       version: 8.0.13
     wrangler:
-      specifier: ^4.91.0
-      version: 4.91.0
+      specifier: ^4.92.0
+      version: 4.92.0
 
 importers:
 
@@ -40,7 +40,7 @@ importers:
         version: 0.7.0
       '@changesets/cli':
         specifier: ^2.31.0
-        version: 2.31.0(@types/node@25.8.0)
+        version: 2.31.0(@types/node@25.9.0)
       '@changesets/config':
         specifier: ^3.1.4
         version: 3.1.4
@@ -55,7 +55,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.8.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.3)(tsx@4.21.0))
+        version: 4.1.6(@types/node@25.9.0)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.27.3)(tsx@4.21.0))
 
   packages/blogger-feed:
     devDependencies:
@@ -64,7 +64,7 @@ importers:
         version: 0.22.0(tsx@4.21.0)(typescript@6.0.3)
       vite:
         specifier: 'catalog:'
-        version: 8.0.13(@types/node@25.8.0)(esbuild@0.27.3)(tsx@4.21.0)
+        version: 8.0.13(@types/node@25.9.0)(esbuild@0.27.3)(tsx@4.21.0)
 
   packages/clc:
     devDependencies:
@@ -120,7 +120,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
-        version: 25.8.0
+        version: 25.9.0
       '@types/prompt-sync':
         specifier: ^4.2.3
         version: 4.2.3
@@ -132,7 +132,7 @@ importers:
         version: 0.22.0(tsx@4.21.0)(typescript@6.0.3)
       wrangler:
         specifier: 'catalog:'
-        version: 4.91.0(@cloudflare/workers-types@4.20260515.1)
+        version: 4.92.0(@cloudflare/workers-types@4.20260519.1)
 
   packages/google-image:
     dependencies:
@@ -155,16 +155,16 @@ importers:
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
-        version: 4.20260515.1
+        version: 4.20260519.1
       hono:
-        specifier: ^4.12.18
-        version: 4.12.18
+        specifier: ^4.12.19
+        version: 4.12.19
       tsdown:
         specifier: 'catalog:'
         version: 0.22.0(tsx@4.21.0)(typescript@6.0.3)
       wrangler:
         specifier: 'catalog:'
-        version: 4.91.0(@cloudflare/workers-types@4.20260515.1)
+        version: 4.92.0(@cloudflare/workers-types@4.20260519.1)
 
   packages/utils:
     dependencies:
@@ -190,7 +190,7 @@ importers:
         version: 0.22.0(tsx@4.21.0)(typescript@6.0.3)
       vite:
         specifier: 'catalog:'
-        version: 8.0.13(@types/node@25.8.0)(esbuild@0.27.3)(tsx@4.21.0)
+        version: 8.0.13(@types/node@25.9.0)(esbuild@0.27.3)(tsx@4.21.0)
 
 packages:
 
@@ -354,38 +354,38 @@ packages:
       workerd:
         optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260511.1':
-    resolution: {integrity: sha512-xQXYe0ILEGKyFFgZ9SlxZV2RkWXxp9mIA5mlqfdEmmSInMHlWRO4H/l6oCXZnQXNH6o3bvmGuNzl6Mac5+Omgg==}
+  '@cloudflare/workerd-darwin-64@1.20260515.1':
+    resolution: {integrity: sha512-Wtw44el2pNbzixvTkWdfeBDTrQwQbJRz7/JUvPKV27I0pQWXbhNJPpM8cstq/pbrU5AGcA/HjFH6yPMRTIRKig==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260511.1':
-    resolution: {integrity: sha512-QOaY4/BlQfDEZgTlrwCPreRIyenYmFWREVP79SSz6K6QBf7bf8ubaATN11NZbouEg19iTMtl5L7FLYdcz1tz7g==}
+  '@cloudflare/workerd-darwin-arm64@1.20260515.1':
+    resolution: {integrity: sha512-X8EqkZej6FfmhF9AVAQ3FhyQRr9acS4RcDunMU2YiuxKHF1IU8zzH3vY30/POaG+rUu9vGDp/VgUl49VPenHJQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20260511.1':
-    resolution: {integrity: sha512-5ZV6SHjU7WSsb9pRPSssckLJgDI5xemv7XpKWM023hMv9Q3jb4ZpkZEeIOGt2Q46E4/fcxfnXeQbL1nukDIpLg==}
+  '@cloudflare/workerd-linux-64@1.20260515.1':
+    resolution: {integrity: sha512-CDC89QxQ7Y7t7RG1Jd9vj/qolE1sQRkI2OSEuV5BMJi0vW/gV4OVG6xjpdK3b1OYnSWDzF7NpvlR5Yg86q7k4g==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260511.1':
-    resolution: {integrity: sha512-BG8rVZZCqTvnwOMPuh+cjt/VbZ3QchxXaBOlfromw+zLQoblSHJorMPZ/JY4/phV7RoP8gB2C84bBPcahvZUnQ==}
+  '@cloudflare/workerd-linux-arm64@1.20260515.1':
+    resolution: {integrity: sha512-WxbW/PToYES4fvHXzsr/5qOiETQs/Z9iZ0mjSZAiEwq5cMLZemzGN0COx+uFb9OvQwzh6Pg159qPFnw3+i9FuA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-windows-64@1.20260511.1':
-    resolution: {integrity: sha512-tGEyfKFArBL0NdqmABqzsIK1vmHdshkdFzCAUo1j6LqYsEpgJWCzvqwX9IpNHEc/AAm0UtPOLhLKhz1DA7HQLA==}
+  '@cloudflare/workerd-windows-64@1.20260515.1':
+    resolution: {integrity: sha512-WmV/iv+MHjYsvkcMVzpM2B5/mf06UUkdpVhZrtMfV9graWjBGPYFvE/eab8748RPVGKh1Xe1vXofLzDSwc08lA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@4.20260515.1':
-    resolution: {integrity: sha512-ruz+9tcG2iIKq5mXU2F00lL6KF5d4QfbAk7fNgvvqf5BelxDXaieyZmSnvA4sQBuemUstt4AEDN9CmJKmfCsDw==}
+  '@cloudflare/workers-types@4.20260519.1':
+    resolution: {integrity: sha512-BMWAwg4RyyZn3zcdoXbqpfogm2DGfNb83DXNCM1oFUMhYtEX8I+B+oxf67YPKvSiAEbzd7nHzW2mLv3eBH8Etw==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -1228,8 +1228,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@25.8.0':
-    resolution: {integrity: sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==}
+  '@types/node@25.9.0':
+    resolution: {integrity: sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==}
 
   '@types/prompt-sync@4.2.3':
     resolution: {integrity: sha512-Ox77gCSx0YyeakGt/qfOZUSFNSSi+sh3ABoGOiCwiO2KODx492BJnUm9oIXS+AHJtqp12iM4RduY6viTJ9bYwA==}
@@ -1517,8 +1517,8 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.19:
+    resolution: {integrity: sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==}
     engines: {node: '>=16.9.0'}
 
   hookable@6.1.1:
@@ -1694,8 +1694,8 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  miniflare@4.20260511.0:
-    resolution: {integrity: sha512-GjTfjtdrDb4LTUcA1S/iz/YKMvSxlbgAfgXpyhM1PQV/xzUYRpKWayq3R1vOQg53Y/g0epaBFaZLA2QbnS/meA==}
+  miniflare@4.20260515.0:
+    resolution: {integrity: sha512-2j0oQWizk1Eu4Cm8tDX7Z+Nsjd0nebIj1TQcQ+Oy1QKeo0Ay9+bdn8wfLAtOj9znDCybDCUlnS1+nYvKXEdfNg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -2144,17 +2144,17 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  workerd@1.20260511.1:
-    resolution: {integrity: sha512-ecODCw4iWIuvuXdfy358zNpGPuO8k2WLMTaM1TKd+DuR6IF/oItVuvjf4BNhiKXlhIYBbD5GQ0gGHBY/IxSJVA==}
+  workerd@1.20260515.1:
+    resolution: {integrity: sha512-MjKOJLcvU45xXedQowvuiHtJTxu4WTHYQeIlF7YmjuqhiI6dImTFxWCEoRQHiskztxuVSNEmdO7/0UfDu6OMnQ==}
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.91.0:
-    resolution: {integrity: sha512-dFzhAd2/DpaHGRrQMQkL8F6AKmjzK2hfbhyTJ+5dcZS6jdl9KG8oxO5oAflIdlsRYnrOzxRxQnvIqwewIq1FXA==}
+  wrangler@4.92.0:
+    resolution: {integrity: sha512-/DKpQHPxkuZbQsO9dFW2700VTD/4DSZMHjy92fO/frNoDRi/zQsFCAd2ONCV6TGqcUoXcP3D8Bo2gj/L4M0qQQ==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^4.20260511.1
+      '@cloudflare/workers-types': ^4.20260515.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -2283,7 +2283,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@changesets/cli@2.31.0(@types/node@25.8.0)':
+  '@changesets/cli@2.31.0(@types/node@25.9.0)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
       '@changesets/assemble-release-plan': 6.0.10
@@ -2299,7 +2299,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@25.8.0)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.9.0)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       enquirer: 2.4.1
@@ -2406,28 +2406,28 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260511.1)':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260515.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260511.1
+      workerd: 1.20260515.1
 
-  '@cloudflare/workerd-darwin-64@1.20260511.1':
+  '@cloudflare/workerd-darwin-64@1.20260515.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260511.1':
+  '@cloudflare/workerd-darwin-arm64@1.20260515.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260511.1':
+  '@cloudflare/workerd-linux-64@1.20260515.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260511.1':
+  '@cloudflare/workerd-linux-arm64@1.20260515.1':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20260511.1':
+  '@cloudflare/workerd-windows-64@1.20260515.1':
     optional: true
 
-  '@cloudflare/workers-types@4.20260515.1': {}
+  '@cloudflare/workers-types@4.20260519.1': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -2779,12 +2779,12 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@inquirer/external-editor@1.0.3(@types/node@25.8.0)':
+  '@inquirer/external-editor@1.0.3(@types/node@25.9.0)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.0
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2950,7 +2950,7 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@25.8.0':
+  '@types/node@25.9.0':
     dependencies:
       undici-types: 7.24.6
 
@@ -2971,13 +2971,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.6(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.3)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.6(vite@8.0.13(@types/node@25.9.0)(esbuild@0.27.3)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.27.3)(tsx@4.21.0)
+      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.27.3)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.1.6':
     dependencies:
@@ -3310,7 +3310,7 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  hono@4.12.18: {}
+  hono@4.12.19: {}
 
   hookable@6.1.1: {}
 
@@ -3446,12 +3446,12 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
-  miniflare@4.20260511.0:
+  miniflare@4.20260515.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
       undici: 7.24.8
-      workerd: 1.20260511.1
+      workerd: 1.20260515.1
       ws: 8.18.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
@@ -3770,7 +3770,7 @@ snapshots:
 
   universalify@0.1.2: {}
 
-  vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.3)(tsx@4.21.0):
+  vite@8.0.13(@types/node@25.9.0)(esbuild@0.27.3)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -3778,15 +3778,15 @@ snapshots:
       rolldown: 1.0.1
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.0
       esbuild: 0.27.3
       fsevents: 2.3.3
       tsx: 4.21.0
 
-  vitest@4.1.6(@types/node@25.8.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.3)(tsx@4.21.0)):
+  vitest@4.1.6(@types/node@25.9.0)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.27.3)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.3)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@25.9.0)(esbuild@0.27.3)(tsx@4.21.0))
       '@vitest/pretty-format': 4.1.6
       '@vitest/runner': 4.1.6
       '@vitest/snapshot': 4.1.6
@@ -3803,10 +3803,10 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.27.3)(tsx@4.21.0)
+      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.27.3)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.0
     transitivePeerDependencies:
       - msw
 
@@ -3826,26 +3826,26 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  workerd@1.20260511.1:
+  workerd@1.20260515.1:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260511.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260511.1
-      '@cloudflare/workerd-linux-64': 1.20260511.1
-      '@cloudflare/workerd-linux-arm64': 1.20260511.1
-      '@cloudflare/workerd-windows-64': 1.20260511.1
+      '@cloudflare/workerd-darwin-64': 1.20260515.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260515.1
+      '@cloudflare/workerd-linux-64': 1.20260515.1
+      '@cloudflare/workerd-linux-arm64': 1.20260515.1
+      '@cloudflare/workerd-windows-64': 1.20260515.1
 
-  wrangler@4.91.0(@cloudflare/workers-types@4.20260515.1):
+  wrangler@4.92.0(@cloudflare/workers-types@4.20260519.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260511.1)
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260515.1)
       blake3-wasm: 2.1.5
       esbuild: 0.27.3
-      miniflare: 4.20260511.0
+      miniflare: 4.20260515.0
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260511.1
+      workerd: 1.20260515.1
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20260515.1
+      '@cloudflare/workers-types': 4.20260519.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,14 +10,14 @@ allowBuilds:
   workerd: true
 
 catalog:
-  "@cloudflare/workers-types": "^4.20260515.1"
-  "@types/node": "^25.8.0"
+  "@cloudflare/workers-types": "^4.20260519.1"
+  "@types/node": "^25.9.0"
   "@types/react": "^19.2.14"
   react: "^19.2.6"
   react-dom: "^19.2.6"
   tsdown: "^0.22.0"
   vite: "^8.0.13"
-  wrangler: "^4.91.0"
+  wrangler: "^4.92.0"
 
 engineStrict: true
 strictPeerDependencies: true
@@ -25,3 +25,6 @@ shellEmulator: true
 preferWorkspacePackages: true
 linkWorkspacePackages: true
 enablePrePostScripts: true
+minimumReleaseAgeExclude:
+  - '@cloudflare/workers-types@4.20260519.1'
+  - '@types/node@25.9.0'


### PR DESCRIPTION
**Summary**

- improve TypeScript type inference
- export additional internal types
- improve compatibility with bundlers that generate type annotations

Some bundlers and build tools rely on exported types to properly generate and preserve type annotations. This change improves interoperability and developer experience for TypeScript consumers.