### PR TITLE
feat(blogger-feed): redesign pagination responses and replace `SDKInputNotFoundError` with null returns

### DIFF
--- a/.changeset/dark-chefs-rest.md
+++ b/.changeset/dark-chefs-rest.md
@@ -1,0 +1,33 @@
+---
+"@deox/blogger-feed": minor
+---
+
+**Pagination API has changed**
+
+List methods now return a pagination object instead of an array with mixed pagination properties.
+
+Before:
+
+```ts
+const feed = new BloggerFeed(url);
+const posts = await feed.posts.list();
+
+posts[0];
+posts.next();
+```
+
+Now:
+
+```ts
+const feed = new BloggerFeed(url);
+const posts = await feed.posts.list();
+
+posts.items[0];
+posts.next();
+```
+
+This affects all list methods:
+
+- `BloggerFeed.posts.list`
+- `BloggerFeed.pages.list`
+- `BloggerFeed.comments.list`

--- a/.changeset/three-streets-leave.md
+++ b/.changeset/three-streets-leave.md
@@ -1,0 +1,41 @@
+---
+"@deox/blogger-feed": minor
+---
+
+**`get` methods now return `null`**
+
+`get` methods now return `null` when an entity is not found instead of throwing `SDKInputNotFoundError`.
+
+The `SDKInputNotFoundError` class has been removed.
+
+Before:
+
+```ts
+const feed = new BloggerFeed(url);
+
+try {
+  const post = await feed.posts.get(id);
+} catch (error) {
+  if (error instanceof SDKInputNotFoundError) {
+    // handle not found
+  }
+}
+```
+
+Now:
+
+```ts
+const feed = new BloggerFeed(url);
+const post = await feed.posts.get(id);
+
+if (post === null) {
+  // handle not found
+}
+```
+
+This affects:
+
+- `BloggerFeed.blog.get`
+- `BloggerFeed.posts.get`
+- `BloggerFeed.pages.get`
+- `BloggerFeed.comments.get`

--- a/packages/blogger-feed/dev/index.ts
+++ b/packages/blogger-feed/dev/index.ts
@@ -31,7 +31,7 @@ const feed = new BloggerFeed('fineshopdesign.com', {
   console.info('.posts.list({ label })', _posts_list_label);
 
   // Posts.get
-  const _posts_get = await feed.posts.get(_posts_list[0].id);
+  const _posts_get = await feed.posts.get(_posts_list.items[0].id);
   console.info('.posts.get():', _posts_get);
 
   // Posts.query
@@ -43,7 +43,7 @@ const feed = new BloggerFeed('fineshopdesign.com', {
   console.info('.pages.list():', _pages_list);
 
   // Pages.get
-  const _pages_get = await feed.pages.get(_pages_list[0].id);
+  const _pages_get = await feed.pages.get(_pages_list.items[0].id);
   console.info('.pages.get():', _pages_get);
 
   // Comments.list
@@ -54,7 +54,7 @@ const feed = new BloggerFeed('fineshopdesign.com', {
   console.info('.comments.list():', _comments_list);
 
   // Comments.get
-  const _comments_get = await feed.comments.get(_comments_list[0].post.id, _comments_list[0].id);
+  const _comments_get = await feed.comments.get(_comments_list.items[0].post.id, _comments_list.items[0].id);
   console.info('.comments.get():', _comments_get);
 })().catch(console.error);
 

--- a/packages/blogger-feed/src/blog.ts
+++ b/packages/blogger-feed/src/blog.ts
@@ -1,29 +1,23 @@
-import { NOT_FOUND_ERRORS } from './constants';
-import { SDKInputNotFoundError } from './errors';
 import { Methods } from './methods';
+import type { Blog } from './types';
 
 /**
  * A class having methods related to Blog
  */
-export class Blog extends Methods {
+export class BlogMethods extends Methods {
   /**
    * Retrieve blog information
    *
    * @returns The blog info
    */
-  async get({ signal }: { signal?: AbortSignal } = {}) {
+  async get({ signal }: { signal?: AbortSignal } = {}): Promise<Blog | null> {
     const { blog } = await this.c.req('./posts/summary', {
       params: {
-        // Do not load entries since we only need blog info
+        // do not load entries since we only need blog info
         maxResults: 0,
       },
       signal,
     });
-
-    // Throw an error if feed doesn't contain blog info
-    if (!blog) {
-      throw new SDKInputNotFoundError(NOT_FOUND_ERRORS.blog);
-    }
 
     return blog;
   }

--- a/packages/blogger-feed/src/blogger-feed.ts
+++ b/packages/blogger-feed/src/blogger-feed.ts
@@ -1,10 +1,10 @@
-import { Blog } from './blog';
+import { BlogMethods } from './blog';
 import { Client } from './client';
-import { Comments } from './comments';
-import { SDKError, SDKInputNotFoundError, SDKRequestError } from './errors';
+import { CommentsMethods } from './comments';
+import { SDKError, SDKRequestError } from './errors';
 import { parseFeed } from './feed-parser';
-import { Pages } from './pages';
-import { Posts } from './posts';
+import { PagesMethods } from './pages';
+import { PostsMethods } from './posts';
 
 /**
  * An interface representing options for {@link BloggerFeed}
@@ -23,14 +23,13 @@ export interface BloggerFeedOptions {
 
 export class BloggerFeed {
   static readonly SDKError = SDKError;
-  static readonly SDKInputNotFoundError = SDKInputNotFoundError;
   static readonly SDKRequestError = SDKRequestError;
   static readonly parseFeed = parseFeed;
 
-  readonly posts: Posts;
-  readonly pages: Pages;
-  readonly comments: Comments;
-  readonly blog: Blog;
+  readonly posts: PostsMethods;
+  readonly pages: PagesMethods;
+  readonly comments: CommentsMethods;
+  readonly blog: BlogMethods;
 
   /**
    * Creates an instance of {@link BloggerFeed}
@@ -40,9 +39,9 @@ export class BloggerFeed {
    */
   constructor(urlOrId: string | URL, options: BloggerFeedOptions = {}) {
     const client = new Client(urlOrId, options);
-    this.posts = new Posts(client);
-    this.pages = new Pages(client);
-    this.comments = new Comments(client);
-    this.blog = new Blog(client);
+    this.posts = new PostsMethods(client);
+    this.pages = new PagesMethods(client);
+    this.comments = new CommentsMethods(client);
+    this.blog = new BlogMethods(client);
   }
 }

--- a/packages/blogger-feed/src/client.ts
+++ b/packages/blogger-feed/src/client.ts
@@ -1,6 +1,6 @@
-import { NOT_FOUND_ERRORS } from './constants';
-import { SDKInputNotFoundError } from './errors';
+import { SDKError } from './errors';
 import { type FetchFeedOptions, fetchFeed } from './request';
+import type { Blog, Feed } from './types';
 import { isString } from './utils';
 
 /**
@@ -15,11 +15,13 @@ export interface ClientOptions {
  * A class for fetching Blogger feed
  */
 export class Client {
-  private jsonp: boolean;
-  private base: string;
+  private _jsonp: boolean;
+  private _base: string;
 
-  private _bU: string | undefined;
-  private _bI: string | undefined;
+  private _blogUrl: string | undefined;
+  private _blogId: string | undefined;
+
+  private _blog?: Blog;
 
   /**
    * Creates an instance of {@link Client}
@@ -29,8 +31,8 @@ export class Client {
    */
   constructor(urlOrId: string | URL, options: ClientOptions = {}) {
     if (isString(urlOrId) && /^\d{12,24}$/.test(urlOrId)) {
-      this._bI = urlOrId;
-      this.base = getServiceBase(urlOrId);
+      this._blogId = urlOrId;
+      this._base = getServiceBase(urlOrId);
     } else {
       let url: URL | null = null;
       if (urlOrId instanceof URL) {
@@ -47,71 +49,60 @@ export class Client {
         throw new Error(`Argument 'urlOrId' has unsupported protocol '${url.protocol}'`);
       }
 
-      this._bU = addSlash(url.origin);
-      this.base = getDomainBase(url.origin);
+      this._blogUrl = trailingSlash(url.origin);
+      this._base = getDomainBase(url.origin);
     }
-    this.jsonp = options.jsonp === true;
+    this._jsonp = options.jsonp === true;
 
     // Throw an error if jsonp is enabled but current environment is not browser
-    if (this.jsonp && (typeof window !== 'object' || typeof document !== 'object')) {
+    if (this._jsonp && (typeof window !== 'object' || typeof document !== 'object')) {
       throw new Error("options.jsonp is set to true but current environment does't support it, please set it to false to use json");
     }
   }
 
-  private _?: {
-    id: string;
-    url: string;
-    serviceBase: string;
-    domainBase: string;
-  };
-
-  get blog() {
-    return (async () => {
-      const { blog } = await this.req('./posts/summary', { params: { maxResults: 0 } });
+  async getBlog(): Promise<{ id: string; url: string }> {
+    if (!this._blog) {
+      const { blog } = await this.req('./posts/summary', {
+        params: {
+          // do not load entries since we only need blog info
+          maxResults: 0,
+        },
+      });
 
       if (!blog) {
-        throw new SDKInputNotFoundError(NOT_FOUND_ERRORS.blog);
+        throw new SDKError('The blog was not found.');
       }
 
-      this._ ??= {
-        id: blog.id,
-        url: blog.url,
-        serviceBase: getServiceBase(blog.id),
-        domainBase: getDomainBase(blog.url),
-      };
+      this._blog = blog;
+    }
 
-      return this._;
-    })();
+    return this._blog;
   }
 
-  get id() {
-    return (async () => {
-      this._bI ??= (await this.blog).id;
-      return this._bI;
-    })();
+  async getBlogId(): Promise<string> {
+    this._blogId ??= (await this.getBlog()).id;
+    return this._blogId;
   }
 
-  get url() {
-    return (async () => {
-      this._bU ??= (await this.blog).url;
-      return this._bU;
-    })();
+  async getBlogUrl(): Promise<string> {
+    this._blogUrl ??= trailingSlash((await this.getBlog()).url);
+    return this._blogUrl;
   }
 
-  get domainBase() {
-    return (async () => getDomainBase(await this.url))();
+  async getDomainBase(): Promise<string> {
+    return getDomainBase(await this.getBlogUrl());
   }
 
-  get serviceBase() {
-    return (async () => getServiceBase(await this.id))();
+  async getServiceBase(): Promise<string> {
+    return getServiceBase(await this.getBlogId());
   }
 
-  async req(path: string, options?: FetchFeedOptions) {
-    return fetchFeed(path, { baseUrl: this.base, jsonp: this.jsonp, ...options });
+  async req(path: string, options?: FetchFeedOptions): Promise<Feed> {
+    return fetchFeed(path, { base: this._base, jsonp: this._jsonp, ...options });
   }
 }
 
-function addSlash(url: string): string {
+function trailingSlash(url: string): string {
   return url.endsWith('/') ? url : `${url}/`;
 }
 
@@ -120,5 +111,5 @@ function getServiceBase(id: string): string {
 }
 
 function getDomainBase(origin: string): string {
-  return `${addSlash(origin)}feeds/`;
+  return `${trailingSlash(origin)}feeds/`;
 }

--- a/packages/blogger-feed/src/comments.ts
+++ b/packages/blogger-feed/src/comments.ts
@@ -1,10 +1,9 @@
-import { NOT_FOUND_ERRORS } from './constants';
-import { SDKInputNotFoundError } from './errors';
-import { Methods } from './methods';
+import { Methods, type WithPagination } from './methods';
+import type { Comment } from './types';
 import { assertNonBlankString, isUndefined } from './utils';
 
 /** Options for {@link Comments.list} */
-export type CommentsListOptions = {
+export interface CommentsListOptions {
   maxResults?: number;
   startIndex?: number;
   orderBy?: 'published' | 'updated';
@@ -14,17 +13,17 @@ export type CommentsListOptions = {
   updatedMax?: Date | string;
   summary?: boolean;
   postId?: string;
-};
+}
 
 /** Options for {@link Comments.get} */
-export type CommentsGetOptions = {
+export interface CommentsGetOptions {
   summary?: boolean;
-};
+}
 
 /**
  * A class having methods related to Comments
  */
-export class Comments extends Methods {
+export class CommentsMethods extends Methods {
   /**
    * Retrieves all the comments of the blog or a post
    *
@@ -32,7 +31,7 @@ export class Comments extends Methods {
    *
    * @returns On success, an Array of Comment
    */
-  async list(options: CommentsListOptions = {}, { signal }: { signal?: AbortSignal } = {}) {
+  async list(options: CommentsListOptions = {}, { signal }: { signal?: AbortSignal } = {}): Promise<WithPagination<'comments'>> {
     const { postId } = options;
 
     // validate post_id if provided
@@ -51,7 +50,7 @@ export class Comments extends Methods {
       result.comments = result.comments.filter((c) => c.post.id === postId);
     }
 
-    return this._p('comments', result);
+    return this._paginate('comments', result);
   }
 
   /**
@@ -63,7 +62,7 @@ export class Comments extends Methods {
    *
    * @returns On success, a Comment
    */
-  async get(postId: string, commentId: string, options: CommentsGetOptions = {}, { signal }: { signal?: AbortSignal } = {}) {
+  async get(postId: string, commentId: string, options: CommentsGetOptions = {}, { signal }: { signal?: AbortSignal } = {}): Promise<Comment | null> {
     assertNonBlankString(postId, "Argument 'postId'");
     assertNonBlankString(commentId, "Argument 'commentId'");
 
@@ -71,18 +70,12 @@ export class Comments extends Methods {
       `./${encodeURI(postId)}/comments/${options.summary === true ? 'summary' : 'default'}/${encodeURI(commentId)}`,
       {
         // We need to use blogger service base url since comments by id through domain is not available
-        baseUrl: await this.c.serviceBase,
+        base: await this.c.getServiceBase(),
         exclude: ['query'],
         signal,
       },
     );
 
-    const comment = comments?.find((c) => c.id === commentId);
-
-    if (!comment) {
-      throw new SDKInputNotFoundError(NOT_FOUND_ERRORS.comment);
-    }
-
-    return comment;
+    return comments?.find((c) => c.id === commentId) ?? null;
   }
 }

--- a/packages/blogger-feed/src/constants.ts
+++ b/packages/blogger-feed/src/constants.ts
@@ -1,22 +1,2 @@
 /** Name for global variable for jsonp callbacks */
-export const JSONP_NAMESPACE = '__deox_blogger_feed_jsonp_callbacks__';
-
-/** Feed ot entry not found error */
-export const NOT_FOUND_ERRORS = {
-  post: {
-    error: 'The post was not found.',
-    code: 'post_not_found',
-  },
-  page: {
-    error: 'The page was not found.',
-    code: 'page_not_found',
-  },
-  comment: {
-    error: 'The comment was not found.',
-    code: 'comment_not_found',
-  },
-  blog: {
-    error: 'The blog was not found.',
-    code: 'blog_not_found',
-  },
-} as const;
+export const JSONP_NAMESPACE: string = '__deox_blogger_feed_jsonp_callbacks__';

--- a/packages/blogger-feed/src/errors.ts
+++ b/packages/blogger-feed/src/errors.ts
@@ -1,5 +1,3 @@
-import type { NOT_FOUND_ERRORS } from './constants';
-
 /**
  * Represents a SDK error
  */
@@ -20,28 +18,5 @@ export class SDKRequestError extends SDKError {
     super(message, options);
     this.name = 'SDKRequestError';
     this.url = String(url);
-  }
-}
-
-/**
- * Represents a error thrown when client is requesting for some resources which does not exists.
- * For example requesting for a post with specific `post_id` but that doesn't exists.
- */
-export class SDKInputNotFoundError<
-  T extends {
-    error: string;
-    code: (typeof NOT_FOUND_ERRORS)[keyof typeof NOT_FOUND_ERRORS]['code'];
-  },
-> extends SDKError {
-  readonly error: T['error'];
-
-  readonly code: T['code'];
-
-  constructor(result: T, options?: ErrorOptions) {
-    super(result.error, options);
-    this.name = 'SDKInputNotFoundError';
-
-    this.error = result.error;
-    this.code = result.code;
   }
 }

--- a/packages/blogger-feed/src/feed-parser.ts
+++ b/packages/blogger-feed/src/feed-parser.ts
@@ -1,8 +1,5 @@
-import type { Author, Blog, Comment, Extended, Feed, Geo, Link, Links, Post, PostCommentInfo } from './types';
+import type { Author, Blog, Comment, Extended, Feed, Geo, Link, Post, PostCommentInfo } from './types';
 import { getNested, isArray, isObject, isString } from './utils';
-
-/** constants */
-const NULL = null;
 
 /**
  * Gets the links details from link array
@@ -11,10 +8,9 @@ const NULL = null;
  *
  * @returns An object containing link and links
  */
-const getLinks = (linkArray: unknown) => {
-  const record: Links = {};
-  const array: Link[] = [];
-  let href: string | null = NULL;
+function getLinks(linkArray: unknown): { alternate: string | null; links: Link[] } {
+  const links: Link[] = [];
+  let href: string | null = null;
 
   if (isArray(linkArray) && linkArray.length > 0) {
     for (let i = 0; i < linkArray.length; i += 1) {
@@ -26,18 +22,12 @@ const getLinks = (linkArray: unknown) => {
       const linkTitleLike = getNested(link, 'title');
 
       if (isString(linkRelLike) && isString(linkHrefLike)) {
-        if (!isArray(record[linkRelLike])) {
-          record[linkRelLike] = [];
-        }
-        const result = {
+        links.push({
           rel: linkRelLike,
           href: linkHrefLike,
-          type: isString(linkTypeLike) ? linkTypeLike : NULL,
-          title: isString(linkTitleLike) ? linkTitleLike : NULL,
-        };
-
-        record[linkRelLike]?.push(result);
-        array.push(result);
+          type: isString(linkTypeLike) ? linkTypeLike : null,
+          title: isString(linkTitleLike) ? linkTitleLike : null,
+        });
 
         if (linkRelLike === 'alternate' && linkTypeLike === 'text/html') {
           href = linkHrefLike;
@@ -46,8 +36,8 @@ const getLinks = (linkArray: unknown) => {
     }
   }
 
-  return { alternate: href, links: record, array };
-};
+  return { alternate: href, links };
+}
 
 /**
  * Gets pagination urls from feed
@@ -56,33 +46,27 @@ const getLinks = (linkArray: unknown) => {
  *
  * @returns An object containing `self`, `previous` and `next` url
  */
-const getPagination = (feed: unknown) => {
-  const result: {
-    self: string | null;
-    previous: string | null;
-    next: string | null;
-  } = {
-    self: NULL,
-    previous: NULL,
-    next: NULL,
-  };
-  const keys = Object.keys(result) as (keyof typeof result)[];
+function getPagination(feed: unknown): Record<'self' | 'previous' | 'next', string | null> {
+  const result: Record<'self' | 'previous' | 'next', string | null> = { self: null, previous: null, next: null };
 
-  const { array } = getLinks(getNested(feed, 'link'));
+  const { links } = getLinks(getNested(feed, 'link'));
 
-  for (let i = 0; i < array.length; i += 1) {
-    const { rel, href, type } = array[i];
-    if (type !== 'text/html') {
-      for (const key of keys) {
-        if (rel === key) {
-          result[key] = href;
-        }
-      }
+  for (let i = 0; i < links.length; i += 1) {
+    const { rel, href, type } = links[i];
+    if (type === 'text/html') {
+      continue;
+    }
+    if (rel === 'self') {
+      result.self = href;
+    } else if (rel === 'previous') {
+      result.previous = href;
+    } else if (rel === 'next') {
+      result.next = href;
     }
   }
 
   return result;
-};
+}
 
 /**
  * Gets category from category array
@@ -91,7 +75,7 @@ const getPagination = (feed: unknown) => {
  *
  * @returns An Array of string representing categories
  */
-const getLabels = (categoryArray: unknown) => {
+function getLabels(categoryArray: unknown): string[] {
   const labels: string[] = [];
 
   if (isArray(categoryArray) && categoryArray.length > 0) {
@@ -106,7 +90,7 @@ const getLabels = (categoryArray: unknown) => {
   }
 
   return labels;
-};
+}
 
 /**
  * Gets Geo details from post entry
@@ -115,17 +99,17 @@ const getLabels = (categoryArray: unknown) => {
  *
  * @returns An object containing `box`, `featureName` and `point`
  */
-const getGeo = (postEntry: unknown): Geo => {
+function getGeo(postEntry: unknown): Geo {
   const [box, featureName, point] = ['georss$box', 'georss$featurename', 'georss$point'].map((key) => {
     const valueLike = getNested(postEntry, key, '$t');
     if (isString(valueLike)) {
       return valueLike;
     }
-    return NULL;
+    return null;
   });
 
   return { box, featureName, point };
-};
+}
 
 /**
  * Gets comments details from link array of a post entry object
@@ -134,16 +118,10 @@ const getGeo = (postEntry: unknown): Geo => {
  *
  * @returns An object containing `feed`, `number` and `title`
  */
-const getPostComments = (linkArray: unknown): PostCommentInfo => {
-  const result: PostCommentInfo = {
-    feed: NULL,
-    number: NULL,
-    title: NULL,
-  };
+function getPostComments(linkArray: unknown): PostCommentInfo {
+  const result: PostCommentInfo = { feed: null, number: null, title: null };
 
-  const {
-    links: { replies },
-  } = getLinks(linkArray);
+  const replies = getLinks(linkArray).links.filter((link) => link.rel === 'replies');
   if (replies) {
     for (const { title, type, href } of replies) {
       if (type === 'text/html' && isString(title)) {
@@ -157,7 +135,7 @@ const getPostComments = (linkArray: unknown): PostCommentInfo => {
   }
 
   return result;
-};
+}
 
 /**
  * Gets authors from author array
@@ -166,7 +144,7 @@ const getPostComments = (linkArray: unknown): PostCommentInfo => {
  *
  * @returns An object containing `name`, `url`, `image` and `public`
  */
-const getAuthors = (authorArray: unknown) => {
+function getAuthors(authorArray: unknown): Author[] {
   const authors: Author[] = [];
 
   if (isArray(authorArray) && authorArray.length > 0) {
@@ -180,15 +158,15 @@ const getAuthors = (authorArray: unknown) => {
       const image =
         isString(authorImageLike) && authorImageLike.trim().toLowerCase() !== 'https://img1.blogblog.com/img/b16-rounded.gif'
           ? authorImageLike
-          : NULL;
-      const url = isString(authorUriLike) ? authorUriLike : NULL;
+          : null;
+      const url = isString(authorUriLike) ? authorUriLike : null;
 
-      authors.push({ name, url, image, public: url !== NULL });
+      authors.push({ name, url, image });
     }
   }
 
   return authors;
-};
+}
 
 /**
  * Gets extended details from a comment entry object
@@ -197,12 +175,8 @@ const getAuthors = (authorArray: unknown) => {
  *
  * @returns An object containing `class`, `time`, `removed`
  */
-const getExtended = (commentEntry: unknown): Extended => {
-  const result: Extended = {
-    class: NULL,
-    time: NULL,
-    removed: false,
-  };
+function getExtended(commentEntry: unknown): Extended {
+  const result: Extended = { class: null, time: null, removed: false };
 
   const extendedArray = getNested(commentEntry, 'gd$extendedProperty');
 
@@ -211,9 +185,7 @@ const getExtended = (commentEntry: unknown): Extended => {
       const extended = (extendedArray[i] || {}) as Record<string, unknown>;
       const { name, value } = extended;
       if (isString(name) && isString(value)) {
-        const data: {
-          [key: string]: ['class' | 'time' | 'removed', string | boolean];
-        } = {
+        const data: Record<string, ['class' | 'time' | 'removed', string | boolean]> = {
           'blogger.itemClass': ['class', value],
           'blogger.displayTime': ['time', value],
           'blogger.contentRemoved': ['removed', value === 'true'],
@@ -230,7 +202,7 @@ const getExtended = (commentEntry: unknown): Extended => {
   }
 
   return result;
-};
+}
 
 /**
  * Gets thumbnail urls from a post entry object
@@ -241,34 +213,35 @@ const getExtended = (commentEntry: unknown): Extended => {
  * Element at index 0 will be thumbnail url or null from post entry.
  * Element at index 1 will be thumbnail url or null from post content otherwise post entry
  */
-const getThumbnail = (postEntry: unknown) => {
-  const postContentLike = getNested(postEntry, 'content', '$t');
-  const postSummaryLike = getNested(postEntry, 'summary', '$t');
+function getThumbnail(postEntry: unknown): [string | null, string | null] {
   const postMediaThumbnailLike = getNested(postEntry, 'media$thumbnail', 'url');
 
-  let content: string | null = NULL;
+  const thumbnail: string | null = isString(postMediaThumbnailLike) ? postMediaThumbnailLike : null;
+
+  const result: [string | null, string | null] = [thumbnail, thumbnail];
+
+  if (thumbnail !== null) {
+    return result;
+  }
+
+  const postContentLike = getNested(postEntry, 'content', '$t');
+  const postSummaryLike = getNested(postEntry, 'summary', '$t');
+
+  let content: string | null = null;
   if (isString(postContentLike)) {
     content = postContentLike;
   } else if (isString(postSummaryLike)) {
     content = postSummaryLike;
   }
 
-  const thumb: string | null = isString(postMediaThumbnailLike) ? postMediaThumbnailLike : NULL;
-
-  const result = [thumb, thumb] as [string | null, string | null];
-
-  if (thumb !== NULL) {
-    return result;
-  }
-
-  const matches = content ? /<img +(.*?)src=([""])([^""]+?)([""])(.*?) *\/?>/i.exec(content) : NULL;
+  const matches = content ? /<img +(.*?)src=([""])([^""]+?)([""])(.*?) *\/?>/i.exec(content) : null;
 
   if (matches?.[3]) {
     result[1] = matches[3];
   }
 
   return result;
-};
+}
 
 /**
  * Gets items per page number from feed object
@@ -277,15 +250,15 @@ const getThumbnail = (postEntry: unknown) => {
  *
  * @returns The items per page number or `null`
  */
-const getItemsPerPage = (feedObject: unknown): number | null => {
+function getItemsPerPage(feedObject: unknown): number | null {
   const resultString = getNested(feedObject, 'openSearch$itemsPerPage', '$t');
 
   if (isString(resultString)) {
     return Number(resultString);
   }
 
-  return NULL;
-};
+  return null;
+}
 
 /**
  * Gets start index number from feed object
@@ -294,15 +267,15 @@ const getItemsPerPage = (feedObject: unknown): number | null => {
  *
  * @returns The start index or `null`
  */
-const getStartIndex = (feedObject: unknown): number | null => {
+function getStartIndex(feedObject: unknown): number | null {
   const resultString = getNested(feedObject, 'openSearch$startIndex', '$t');
 
   if (isString(resultString)) {
     return Number(resultString);
   }
 
-  return NULL;
-};
+  return null;
+}
 
 /**
  * Gets total result number from feed object
@@ -311,15 +284,15 @@ const getStartIndex = (feedObject: unknown): number | null => {
  *
  * @returns The total result or `null`
  */
-const getTotalResult = (feedObject: unknown): number | null => {
+function getTotalResult(feedObject: unknown): number | null {
   const resultString = getNested(feedObject, 'openSearch$totalResults', '$t');
 
   if (isString(resultString)) {
     return Number(resultString);
   }
 
-  return NULL;
-};
+  return null;
+}
 
 /**
  * Gets blog details from feed object
@@ -328,7 +301,7 @@ const getTotalResult = (feedObject: unknown): number | null => {
  *
  * @returns The {@link Blog} if available otherwise `null`
  */
-const getBlog = (feedObject: unknown): Blog | null => {
+function getBlog(feedObject: unknown): Blog | null {
   const feedIdLike = getNested(feedObject, 'id', '$t');
   const feedTitleLike = getNested(feedObject, 'title', '$t');
   const feedSubtitleLike = getNested(feedObject, 'subtitle', '$t');
@@ -339,22 +312,20 @@ const getBlog = (feedObject: unknown): Blog | null => {
   if (isObject(feedObject) && isString(feedIdLike) && isString(feedTitleLike) && isString(feedUpdatedLike) && isString(alternate)) {
     const feedCategoryLike = getNested(feedObject, 'category');
 
-    const blog = {
+    return {
       id: feedIdLike.replace(/^.*blog-(\d+).*$/, '$1'),
       title: feedTitleLike,
-      subtitle: isString(feedSubtitleLike) ? feedSubtitleLike : NULL,
+      subtitle: isString(feedSubtitleLike) ? feedSubtitleLike : null,
       labels: getLabels(feedCategoryLike),
       url: alternate,
       links,
       updated: feedUpdatedLike,
       author: getAuthors(getNested(feedObject, 'author'))[0],
     };
-
-    return blog;
   }
 
-  return NULL;
-};
+  return null;
+}
 
 /**
  * Gets post details from post entry object
@@ -363,7 +334,7 @@ const getBlog = (feedObject: unknown): Blog | null => {
  *
  * @returns The {@link Post} if available otherwise `null`
  */
-const getPost = (postEntry: unknown): Post | null => {
+function getPost(postEntry: unknown): Post | null {
   const postIdLike = getNested(postEntry, 'id', '$t');
   const postTitleLike = getNested(postEntry, 'title', '$t');
   const postPublishedLike = getNested(postEntry, 'published', '$t');
@@ -383,7 +354,7 @@ const getPost = (postEntry: unknown): Post | null => {
   ) {
     const [thumbnail, thumbnailAlt] = getThumbnail(postEntry);
 
-    const post: Post = {
+    return {
       id: postIdLike.replace(/^.*(?:page|post)-(\d+)$/, '$1'),
       title: postTitleLike,
       published: postPublishedLike,
@@ -394,17 +365,15 @@ const getPost = (postEntry: unknown): Post | null => {
       author: getAuthors(getNested(postEntry, 'author'))[0],
       thumbnail,
       thumbnailAlt,
-      summary: isString(postSummaryLike) ? postSummaryLike : NULL,
-      content: isString(postContentLike) ? postContentLike : NULL,
+      summary: isString(postSummaryLike) ? postSummaryLike : null,
+      content: isString(postContentLike) ? postContentLike : null,
       comments: getPostComments(postLinkLike),
       geo: getGeo(postEntry),
     };
-
-    return post;
   }
 
-  return NULL;
-};
+  return null;
+}
 
 /**
  * Gets comment details from comment entry object
@@ -413,7 +382,7 @@ const getPost = (postEntry: unknown): Post | null => {
  *
  * @returns The {@link Comment} if available otherwise `null`
  */
-const getComment = (commentEntry: unknown): Comment | null => {
+function getComment(commentEntry: unknown): Comment | null {
   const commentIdLike = getNested(commentEntry, 'id', '$t');
   const commentTitleLike = getNested(commentEntry, 'title', '$t');
   const commentPublishedLike = getNested(commentEntry, 'published', '$t');
@@ -436,31 +405,29 @@ const getComment = (commentEntry: unknown): Comment | null => {
     isString(commentInReplyToHrefLike) &&
     isString(commentInReplyToRefLike)
   ) {
-    const inReplyToMatches = links.related?.[0].href.match(/\/feeds\/(.*)\/comments\/[^/]+\/(\d+)/);
+    const inReplyToMatches = links.find((link) => link.rel === 'related')?.href.match(/\/feeds\/(.*)\/comments\/[^/]+\/(\d+)/);
 
-    const comment: Comment = {
+    return {
       title: commentTitleLike,
       published: commentPublishedLike,
       updated: commentUpdatedLike,
       url: alternate,
       links,
       author: getAuthors(getNested(commentEntry, 'author'))[0],
-      summary: isString(commentSummaryLike) ? commentSummaryLike : NULL,
-      content: isString(commentContentLike) ? commentContentLike : NULL,
+      summary: isString(commentSummaryLike) ? commentSummaryLike : null,
+      content: isString(commentContentLike) ? commentContentLike : null,
       extended: getExtended(commentEntry),
       id: commentIdLike.replace(/^.*(?:page|post)-(\d+)$/, '$1'),
       post: {
         id: commentInReplyToRefLike.replace(/^.*(?:page|post)-(\d+)$/, '$1'),
         url: commentInReplyToHrefLike.split('?')[0],
       },
-      inReplyTo: inReplyToMatches?.[2] ?? NULL,
+      inReplyTo: inReplyToMatches?.[2] ?? null,
     };
-
-    return comment;
   }
 
-  return NULL;
-};
+  return null;
+}
 
 /**
  * Gets the posts and comments from entry array
@@ -469,9 +436,9 @@ const getComment = (commentEntry: unknown): Comment | null => {
  *
  * @returns An object containing `posts` and `comments`
  */
-const getEntries = (entryArray: unknown) => {
-  let posts: Post[] | null = NULL;
-  let comments: Comment[] | null = NULL;
+function getEntries(entryArray: unknown): { posts: Post[] | null; comments: Comment[] | null } {
+  let posts: Post[] | null = null;
+  let comments: Comment[] | null = null;
 
   if (isArray(entryArray)) {
     posts = [];
@@ -498,7 +465,7 @@ const getEntries = (entryArray: unknown) => {
   }
 
   return { posts, comments };
-};
+}
 
 /**
  * Gets all possible information from entry object and feed object
@@ -508,12 +475,12 @@ const getEntries = (entryArray: unknown) => {
  *
  * @returns An object
  */
-const getFeedFromEntry = (entryArray: unknown, feedObject?: unknown) => {
+function getFeedFromEntry(entryArray: unknown, feedObject?: unknown): Feed {
   const { posts, comments } = getEntries(entryArray);
 
   const pagination = getPagination(feedObject);
 
-  const feed: Feed = {
+  return {
     blog: getBlog(feedObject),
     links: getLinks(getNested(feedObject, 'link')).links,
     posts,
@@ -525,9 +492,7 @@ const getFeedFromEntry = (entryArray: unknown, feedObject?: unknown) => {
     previousUrl: pagination.previous,
     nextUrl: pagination.next,
   };
-
-  return feed;
-};
+}
 
 /**
  * Get entry array from input
@@ -540,15 +505,15 @@ const getFeedFromEntry = (entryArray: unknown, feedObject?: unknown) => {
  *
  * @returns Array of entry object
  */
-const getEntryArray = (input: unknown) => {
+function getEntryArray(input: unknown): unknown[] | null {
   if (isArray(input)) {
     return input as unknown[];
   }
   if (isObject(input)) {
     return [input];
   }
-  return NULL;
-};
+  return null;
+}
 
 /**
  * Get the information from Blogger feed json object
@@ -565,7 +530,7 @@ const getEntryArray = (input: unknown) => {
  *
  * @returns An object containing information from feed
  */
-export const parseFeed = (input: unknown) => {
+export function parseFeed(input: unknown): Feed {
   const inputFeedLike = getNested(input, 'feed');
 
   // Check if input.feed is an object
@@ -576,4 +541,4 @@ export const parseFeed = (input: unknown) => {
 
   const inputEntryLike = getNested(input, 'entry');
   return getFeedFromEntry(getEntryArray(inputEntryLike));
-};
+}

--- a/packages/blogger-feed/src/iife.ts
+++ b/packages/blogger-feed/src/iife.ts
@@ -1,7 +1,7 @@
 import { BloggerFeed } from './blogger-feed';
 
-const getGlobalObject = () => (typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : self);
-
 const GLOBAL_NAME = 'BloggerFeed';
+
+const getGlobalObject = () => (typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : self);
 
 (getGlobalObject() as unknown as { [GLOBAL_NAME]: typeof BloggerFeed })[GLOBAL_NAME] = BloggerFeed;

--- a/packages/blogger-feed/src/index.ts
+++ b/packages/blogger-feed/src/index.ts
@@ -2,7 +2,6 @@ export { BloggerFeed, type BloggerFeedOptions } from './blogger-feed';
 
 export {
   SDKError,
-  SDKInputNotFoundError,
   SDKRequestError,
 } from './errors';
 
@@ -16,7 +15,6 @@ export type {
   Feed,
   Geo,
   Link,
-  Links,
   Post,
   PostCommentInfo,
 } from './types';

--- a/packages/blogger-feed/src/methods.ts
+++ b/packages/blogger-feed/src/methods.ts
@@ -1,34 +1,34 @@
 import type { Client } from './client';
 import type { Comment, Feed, Post } from './types';
-import { addProperties } from './utils';
 
-type PaginationMap = {
+interface PaginationItemsMap {
   posts: Post[];
   comments: Comment[];
-};
+}
 
-/** Pagination props */
-export interface PaginationProps<T extends keyof PaginationMap> {
+export interface WithPagination<T extends keyof PaginationItemsMap> {
+  readonly items: PaginationItemsMap[T];
   readonly itemsPerPage: number | null;
   readonly startIndex: number | null;
   readonly totalResults: number | null;
   readonly selfUrl: string | null;
   readonly previousUrl: string | null;
   readonly nextUrl: string | null;
-  next(requestOptions?: { signal?: AbortSignal }): Promise<(PaginationMap[T] & PaginationProps<T>) | null>;
-  previous(requestOptions?: { signal?: AbortSignal }): Promise<(PaginationMap[T] & PaginationProps<T>) | null>;
+  readonly next: (requestOptions?: { signal?: AbortSignal }) => Promise<WithPagination<T> | null>;
+  readonly previous: (requestOptions?: { signal?: AbortSignal }) => Promise<WithPagination<T> | null>;
 }
 
 export class Methods {
-  protected c: Client;
+  protected readonly c: Client;
 
   constructor(client: Client) {
     this.c = client;
   }
 
   /** Adds pagination properties and methods to feed entries array */
-  protected _p<T extends keyof PaginationMap>(type: T, feed: Feed) {
-    const properties: PaginationProps<T> = {
+  protected _paginate<T extends keyof PaginationItemsMap>(type: T, feed: Feed): WithPagination<T> {
+    return {
+      items: ((type === 'comments' ? feed.comments : feed.posts) ?? []) as PaginationItemsMap[T],
       itemsPerPage: feed.itemsPerPage,
       startIndex: feed.startIndex,
       totalResults: feed.totalResults,
@@ -36,25 +36,21 @@ export class Methods {
       previousUrl: feed.previousUrl,
       nextUrl: feed.nextUrl,
       previous: async ({ signal } = {}) => {
-        if (properties.previousUrl) {
-          const result = await this.c.req(properties.previousUrl, {
-            signal,
-          });
-          return this._p(type, result);
+        if (!feed.previousUrl) {
+          return null;
         }
-        return null;
+        const result = await this.c.req(feed.previousUrl, { signal });
+        return this._paginate(type, result);
       },
       next: async ({ signal } = {}) => {
-        if (properties.nextUrl) {
-          const result = await this.c.req(properties.nextUrl, {
-            signal,
-          });
-          return this._p(type, result);
+        if (!feed.nextUrl) {
+          return null;
         }
-        return null;
+        const result = await this.c.req(feed.nextUrl, {
+          signal,
+        });
+        return this._paginate(type, result);
       },
     };
-
-    return addProperties(((type === 'comments' ? feed.comments : feed.posts) ?? []) as PaginationMap[T], properties);
   }
 }

--- a/packages/blogger-feed/src/pages.ts
+++ b/packages/blogger-feed/src/pages.ts
@@ -1,10 +1,9 @@
-import { NOT_FOUND_ERRORS } from './constants';
-import { SDKInputNotFoundError } from './errors';
-import { Methods } from './methods';
+import { Methods, type WithPagination } from './methods';
+import type { Post } from './types';
 import { assertNonBlankString } from './utils';
 
 /** Options for {@link Pages.list} */
-export type PagesListOptions = {
+export interface PagesListOptions {
   maxResults?: number;
   startIndex?: number;
   orderBy?: 'published' | 'updated';
@@ -13,15 +12,17 @@ export type PagesListOptions = {
   updatedMin?: Date | string;
   updatedMax?: Date | string;
   summary?: boolean;
-};
+}
 
 /** Options for {@link Pages.get} */
-export type PagesGetOptions = { summary?: boolean };
+export interface PagesGetOptions {
+  summary?: boolean;
+}
 
 /**
  * A class having methods related to Pages
  */
-export class Pages extends Methods {
+export class PagesMethods extends Methods {
   /**
    * Retrieves all the pages of the blog
    *
@@ -29,14 +30,14 @@ export class Pages extends Methods {
    *
    * @returns On success, an Array of Post
    */
-  async list(options: PagesListOptions = {}, { signal }: { signal?: AbortSignal } = {}) {
+  async list(options: PagesListOptions = {}, { signal }: { signal?: AbortSignal } = {}): Promise<WithPagination<'posts'>> {
     const result = await this.c.req(`./pages/${options.summary === true ? 'summary' : 'default'}`, {
       params: options,
       exclude: ['query'],
       signal,
     });
 
-    return this._p('posts', result);
+    return this._paginate('posts', result);
   }
 
   /**
@@ -47,7 +48,7 @@ export class Pages extends Methods {
    *
    * @returns On success, a Post
    */
-  async get(pageId: string, options: PagesGetOptions = {}, { signal }: { signal?: AbortSignal } = {}) {
+  async get(pageId: string, options: PagesGetOptions = {}, { signal }: { signal?: AbortSignal } = {}): Promise<Post | null> {
     assertNonBlankString(pageId, "Argument 'pageId'");
 
     const { posts } = await this.c.req(`./pages/${options.summary === true ? 'summary' : 'default'}/${encodeURI(pageId)}`, {
@@ -55,11 +56,6 @@ export class Pages extends Methods {
       signal,
     });
 
-    const page = posts?.find((p) => p.id === pageId);
-
-    // Throw an error if the page was not found
-    if (!page) throw new SDKInputNotFoundError(NOT_FOUND_ERRORS.page);
-
-    return page;
+    return posts?.find((p) => p.id === pageId) ?? null;
   }
 }

--- a/packages/blogger-feed/src/posts.ts
+++ b/packages/blogger-feed/src/posts.ts
@@ -1,10 +1,9 @@
-import { NOT_FOUND_ERRORS } from './constants';
-import { SDKInputNotFoundError } from './errors';
-import { Methods } from './methods';
+import { Methods, type WithPagination } from './methods';
+import type { Post } from './types';
 import { assertNonBlankString, isUndefined } from './utils';
 
 /** Options for {@link Posts.list} */
-export type PostsListOptions = {
+export interface PostsListOptions {
   maxResults?: number;
   startIndex?: number;
   orderBy?: 'published' | 'updated';
@@ -14,15 +13,17 @@ export type PostsListOptions = {
   updatedMax?: Date | string;
   label?: string;
   summary?: boolean;
-};
+}
 
 /** Options for {@link Posts.get} */
-export type PostsGetOptions = { summary?: boolean };
+export interface PostsGetOptions {
+  summary?: boolean;
+}
 
 /** Options for {@link Posts.query} */
-export type PostsQueryOptions = Omit<PostsListOptions, 'label'>;
+export interface PostsQueryOptions extends Omit<PostsListOptions, 'label'> {}
 
-export class Posts extends Methods {
+export class PostsMethods extends Methods {
   /**
    * Retrieves all the posts of the blog
    *
@@ -30,7 +31,7 @@ export class Posts extends Methods {
    *
    * @returns On success, an Array of Post
    */
-  async list(options: PostsListOptions = {}, { signal }: { signal?: AbortSignal } = {}) {
+  async list(options: PostsListOptions = {}, { signal }: { signal?: AbortSignal } = {}): Promise<WithPagination<'posts'>> {
     const { label } = options;
 
     // validate label if provided
@@ -44,7 +45,7 @@ export class Posts extends Methods {
       signal,
     });
 
-    return this._p('posts', result);
+    return this._paginate('posts', result);
   }
 
   /**
@@ -55,7 +56,7 @@ export class Posts extends Methods {
    *
    * @returns On success, a Post
    */
-  async get(postId: string, options: PostsGetOptions = {}, { signal }: { signal?: AbortSignal } = {}) {
+  async get(postId: string, options: PostsGetOptions = {}, { signal }: { signal?: AbortSignal } = {}): Promise<Post | null> {
     assertNonBlankString(postId, "Argument 'postId'");
 
     const { posts } = await this.c.req(`./posts/${options.summary === true ? 'summary' : 'default'}/${encodeURIComponent(postId)}`, {
@@ -63,12 +64,7 @@ export class Posts extends Methods {
       signal,
     });
 
-    const post = posts?.find((p) => p.id === postId);
-
-    // Throw an error if the post was not found
-    if (!post) throw new SDKInputNotFoundError(NOT_FOUND_ERRORS.post);
-
-    return post;
+    return posts?.find((p) => p.id === postId) ?? null;
   }
 
   /**
@@ -79,7 +75,7 @@ export class Posts extends Methods {
    *
    * @returns On success, an Array of Post
    */
-  async query(query: string, options: PostsQueryOptions = {}, { signal }: { signal?: AbortSignal } = {}) {
+  async query(query: string, options: PostsQueryOptions = {}, { signal }: { signal?: AbortSignal } = {}): Promise<WithPagination<'posts'>> {
     assertNonBlankString(query, "Argument 'query'");
 
     const result = await this.c.req(`./posts/${options.summary === true ? 'summary' : 'default'}`, {
@@ -90,6 +86,6 @@ export class Posts extends Methods {
       signal,
     });
 
-    return this._p('posts', result);
+    return this._paginate('posts', result);
   }
 }

--- a/packages/blogger-feed/src/request.ts
+++ b/packages/blogger-feed/src/request.ts
@@ -1,76 +1,37 @@
 import { JSONP_NAMESPACE } from './constants';
 import { SDKError, SDKRequestError } from './errors';
 import { parseFeed } from './feed-parser';
-import { generateId, isObject } from './utils';
+import type { Feed } from './types';
+import { generateId } from './utils';
 
-/** An interface representing options for {@link RequestURL} */
-export interface RequestURLOptions {
-  /**
-   * Indicates whether to clear existing search queries
-   */
-  clearParams?: boolean;
+/**
+ * Fetches JSON using Fetch API
+ *
+ * @param url The url to fetch
+ *
+ * @returns The json data
+ */
+async function fetchJSON<T = unknown>(url: string | URL, { signal }: { signal?: AbortSignal } = {}): Promise<T> {
+  const response = await fetch(url, {
+    signal,
+  }).catch((error) => {
+    throw new SDKRequestError('Fetch to JSON', String(url), {
+      cause: error,
+    });
+  });
 
-  /**
-   * A record of key value which should to added to search queries
-   */
-  params?: Record<string, string | number | boolean | undefined | (string | number | boolean | undefined)[]>;
-}
-
-/** Constructs an `URL` object for endpoints */
-export class RequestURL extends URL {
-  constructor(url: string | URL, base?: string | URL | undefined, options: RequestURLOptions = {}) {
-    super(url, base);
-    const { searchParams } = this;
-    if (options.clearParams) {
-      searchParams.forEach((_value, key, params) => {
-        params.delete(key);
-      });
-    }
-    const append = (key: string, value: string | number | boolean | undefined) => {
-      if (['string', 'boolean', 'number'].includes(typeof value)) {
-        searchParams.append(key, String(value));
-      }
-    };
-    if (isObject(options.params)) {
-      const queries = options.params;
-      for (const key in queries) {
-        const value = queries[key];
-        if (Array.isArray(value)) {
-          for (const e of value) {
-            append(key, e);
-          }
-        } else {
-          append(key, value);
-        }
-      }
-    }
+  if (!response.ok) {
+    await response.body?.cancel();
+    throw new SDKRequestError(`Failed to fetch ${response.url} (status: ${response.status})`, response.url);
   }
-}
 
-/**
- * An interface of parameters which can be used for blogger feed api
- */
-export interface Params {
-  maxResults?: number;
-  startIndex?: number;
-  orderBy?: 'lastmodified' | 'starttime' | 'published' | 'updated';
-  publishedMin?: Date | string;
-  publishedMax?: Date | string;
-  updatedMin?: Date | string;
-  updatedMax?: Date | string;
-  query?: string;
-}
+  const contentType = response.headers.get('Content-Type')?.includes('application/json');
+  if (!contentType) {
+    await response.body?.cancel();
+    throw new SDKRequestError(`Response was success but Content-Type '${contentType}' is not supported`, response.url);
+  }
 
-/**
- * An interface representing options for {@link fetchFeed}
- */
-export interface FetchFeedOptions {
-  params?: Params;
-  include?: (keyof Params)[];
-  exclude?: (keyof Params)[];
-  baseUrl?: string | URL;
-  jsonp?: boolean;
-  signal?: AbortSignal;
+  return (await response.json()) as T;
 }
 
 /** A callback function for constructing jsonp url with given callback param */
@@ -87,7 +48,7 @@ const queueJSONP: Record<string, (data: unknown) => void> = {};
  *
  * @returns The data which was sent to the callback
  */
-const fetchJSONP = async <T = unknown>(getUrl: JSONPGetUrl, scriptOptions?: Record<string, unknown>) => {
+async function fetchJSONP<T = unknown>(getUrl: JSONPGetUrl, scriptOptions?: Record<string, unknown>): Promise<T> {
   (window as unknown as Record<string, unknown>)[JSONP_NAMESPACE] ??= queueJSONP;
 
   const id = `callback_${generateId()}`;
@@ -112,37 +73,47 @@ const fetchJSONP = async <T = unknown>(getUrl: JSONPGetUrl, scriptOptions?: Reco
     };
     document.head.appendChild(script);
   });
+}
+
+/**
+ * An interface of parameters which can be used for blogger feed api
+ */
+export interface Params {
+  maxResults?: number;
+  startIndex?: number;
+  orderBy?: 'lastmodified' | 'starttime' | 'published' | 'updated';
+  publishedMin?: Date | string;
+  publishedMax?: Date | string;
+  updatedMin?: Date | string;
+  updatedMax?: Date | string;
+  sort?: string;
+  query?: string;
+}
+
+/** List of supported query params options and map to valid params */
+const validParamsMap: Record<keyof Params, string> = {
+  maxResults: 'max-results',
+  startIndex: 'start-index',
+  orderBy: 'orderby',
+  publishedMin: 'published-min',
+  publishedMax: 'published-max',
+  updatedMin: 'updated-min',
+  updatedMax: 'updated-max',
+  sort: 'sort',
+  query: 'q',
 };
 
 /**
- * Fetches JSON using Fetch API
- *
- * @param url The url to fetch
- *
- * @returns The json data
+ * An interface representing options for {@link fetchFeed}
  */
-const fetchJSON = async <T = unknown>(url: string | URL, { signal }: { signal?: AbortSignal } = {}) => {
-  const response = await fetch(url, {
-    signal,
-  }).catch((error) => {
-    throw new SDKRequestError('Fetch to JSON', String(url), {
-      cause: error,
-    });
-  });
-
-  if (!response.ok) {
-    await response.body?.cancel();
-    throw new SDKRequestError(`Failed to fetch ${response.url} (status: ${response.status})`, response.url);
-  }
-
-  const contentType = response.headers.get('Content-Type')?.includes('application/json');
-  if (!contentType) {
-    await response.body?.cancel();
-    throw new SDKRequestError(`Response was success but Content-Type '${contentType}' is not supported`, response.url);
-  }
-
-  return (await response.json()) as T;
-};
+export interface FetchFeedOptions {
+  params?: Params;
+  include?: (keyof Params)[];
+  exclude?: (keyof Params)[];
+  base?: string | URL;
+  jsonp?: boolean;
+  signal?: AbortSignal;
+}
 
 /**
  * Fetches and parses the blogger feed
@@ -152,36 +123,21 @@ const fetchJSON = async <T = unknown>(url: string | URL, { signal }: { signal?: 
  *
  * @returns The parsed feed data
  */
-export const fetchFeed = async (path: string | URL, { params, include, exclude, baseUrl, jsonp, signal }: FetchFeedOptions = {}) => {
-  const queries: RequestURLOptions['params'] = {};
-
-  // List of supported search params options and map to valid params
-  const paramsMap: Record<string, string> = {
-    maxResults: 'max-results',
-    startIndex: 'start-index',
-    orderBy: 'orderby',
-    publishedMin: 'published-min',
-    publishedMax: 'published-max',
-    updatedMin: 'updated-min',
-    updatedMax: 'updated-max',
-    sort: 'sort',
-    query: 'q',
-  };
+export async function fetchFeed(path: string | URL, { params, include, exclude, base, jsonp, signal }: FetchFeedOptions = {}): Promise<Feed> {
+  const queries: Record<string, string> = {};
 
   if (params) {
     for (const key in params) {
+      if (!(key in validParamsMap)) {
+        continue;
+      }
       const value = params[key as keyof typeof params];
-      if (key in paramsMap) {
-        let shouldAllow = true;
-        if (include) {
-          shouldAllow = (include as string[]).includes(key);
-        }
-        if (exclude) {
-          shouldAllow = !(exclude as string[]).includes(key);
-        }
-        if (shouldAllow) {
-          queries[paramsMap[key]] = value instanceof Date ? value.toISOString() : String(value);
-        }
+
+      const allowed = (!include || (include as string[]).includes(key)) && (!exclude || !(exclude as string[]).includes(key));
+
+      if (allowed) {
+        const mapped = validParamsMap[key as keyof Params];
+        queries[mapped] = value instanceof Date ? value.toISOString() : String(value);
       }
     }
   }
@@ -190,14 +146,23 @@ export const fetchFeed = async (path: string | URL, { params, include, exclude, 
   queries.alt = 'json';
 
   // Set redirect to false
-  queries.redirect = false;
+  queries.redirect = 'false';
 
-  const endpoint = new RequestURL(path, baseUrl, { params: queries });
+  const endpoint = new URL(path, base);
 
-  const json = await (jsonp
-    ? fetchJSONP(({ callback }) => new RequestURL(endpoint, undefined, { params: { callback } }))
-    : fetchJSON(endpoint, { signal }));
+  for (const name in queries) {
+    endpoint.searchParams.append(name, queries[name]);
+  }
 
-  // Parse the feed object to feed info
-  return parseFeed(json);
-};
+  if (jsonp) {
+    const data = await fetchJSONP(({ callback }) => {
+      const url = new URL(endpoint);
+      url.searchParams.append('callback', callback);
+      return url;
+    });
+    return parseFeed(data);
+  }
+
+  const data = await fetchJSON(endpoint, { signal });
+  return parseFeed(data);
+}

--- a/packages/blogger-feed/src/types/feed.ts
+++ b/packages/blogger-feed/src/types/feed.ts
@@ -13,11 +13,6 @@ export interface Author {
    * The image url of the author if available otherwise null
    */
   image: string | null;
-
-  /**
-   * Indicates whether author profile is publicly accessible
-   */
-  public: boolean;
 }
 
 export interface Extended {
@@ -43,8 +38,6 @@ export interface Link {
   type: string | null;
   title: string | null;
 }
-
-export type Links = Record<string, Link[] | undefined>;
 
 export type Geo = {
   box: string | null;
@@ -74,7 +67,7 @@ export interface Blog {
    */
   url: string;
 
-  links: Links;
+  links: Link[];
 
   /**
    * The id of the blog
@@ -125,7 +118,7 @@ export interface Post {
    */
   url: string;
 
-  links: Links;
+  links: Link[];
 
   /**
    * The id of the post
@@ -191,7 +184,7 @@ export interface Comment {
    */
   url: string;
 
-  links: Links;
+  links: Link[];
 
   id: string;
 
@@ -240,7 +233,7 @@ export interface Comment {
 
 export interface Feed {
   blog: Blog | null;
-  links: Links;
+  links: Link[];
   posts: Post[] | null;
   comments: Comment[] | null;
   itemsPerPage: number | null;

--- a/packages/blogger-feed/src/utils.ts
+++ b/packages/blogger-feed/src/utils.ts
@@ -14,48 +14,17 @@ export function isObject(input: unknown): input is NonNullable<object> {
   return typeof input === 'object' && input !== null && !isArray(input);
 }
 
-/** Checks whether the deep nested property in an object exists and gets its value */
-export function nestedData(obj: unknown, ...levels: string[]): { exists: boolean; value: unknown } {
+export function getNested(obj: unknown, ...levels: string[]): unknown {
   let current = obj;
 
   for (let i = 0; i < levels.length; i += 1) {
     if (!current || !Object.hasOwn(current, levels[i])) {
-      return { exists: false, value: undefined };
+      return undefined;
     }
     current = current[levels[i] as never];
   }
 
-  return { exists: true, value: current };
-}
-
-/** Gets the deep nested property value in an object */
-export function getNested(obj: unknown, ...args: string[]): unknown {
-  return nestedData(obj, ...args).value;
-}
-
-/** Converts object to property descriptor map */
-function getConfigurations<M extends Record<string | number, unknown>>(properties: M): PropertyDescriptorMap {
-  return Object.entries(properties).reduce<PropertyDescriptorMap>((acc, [key, value]) => {
-    acc[key] = {
-      value,
-    };
-
-    return acc;
-  }, {});
-}
-
-/** Adds properties to existing object */
-export function addProperties<T extends NonNullable<unknown>, I extends NonNullable<unknown>, M extends NonNullable<unknown>>(
-  target: T,
-  immutable: I,
-  mutable?: M,
-) {
-  if (mutable) {
-    Object.assign(target, mutable);
-  }
-  Object.defineProperties(target, getConfigurations(immutable));
-
-  return target as T & M & I;
+  return current;
 }
 
 /** asserts: input must be string */


### PR DESCRIPTION
The SDK response API has been redesigned to improve consistency and type safety.

- Pagination responses no longer extend arrays with additional pagination methods and metadata. List methods now return a dedicated pagination object containing an `items` array alongside pagination helpers like `next()`.
- Additionally, all `get` methods now return `null` when an entity is not found instead of throwing `SDKInputNotFoundError`. As part of this change, the `SDKInputNotFoundError` class has been removed entirely.

These changes affect all `list` and `get` methods across blog, posts, pages, and comments APIs and require migration for existing consumers relying on the previous behavior.